### PR TITLE
fix: handle more pdfs when flattening

### DIFF
--- a/lib/flatten-pdf.js
+++ b/lib/flatten-pdf.js
@@ -10,10 +10,20 @@ export default async function flattenPDF(pdfBytes) {
   const form = pdfDoc.getForm();
 
   for (const field of form.getFields()) {
-    // See: https://github.com/Hopding/pdf-lib/issues/1168#issuecomment-1321581900
-    if (field.isExported()) {
-      while (field.acroField.getWidgets().length) {
-          field.acroField.removeWidget(0);
+    const widgets = field.acroField.getWidgets();
+
+    for (let idx = widgets.length - 1; idx >= 0; idx--) {
+      const widget = widgets[idx];
+      /* As of May 2025, documents coming from SigningHub contain two signature
+         fields, one named SignatureX, the other SH_SIGNATURE_XXXXXX. The original
+         flattening method simply flattened the whole PDF, but given these new
+         SigningHub pdfs, this would result in an error when calling the flatten()
+         method. To fix this error we remove the SignatureX's widget before calling
+         the flatten() method.
+         Why use the AP() method to find the widget we want to remove? There's no
+         good reason, it's one field that is visibly different. */
+      if (!widget.AP()) {
+        field.acroField.removeWidget(idx);
       }
     }
   }


### PR DESCRIPTION
The previous fix did not correctly flatten PDFs coming from the IF. This fix should correctly handle those PDFs, but the fix isn't very clear. If users start uploading signed PDFs from other departments (or rather, signed with other tools), we should pay attention to how they behave with this logic.