### PR TITLE
fix: replace pdf-lib version

### DIFF
--- a/lib/flatten-pdf.js
+++ b/lib/flatten-pdf.js
@@ -1,4 +1,4 @@
-import { PDFDocument } from "pdf-lib";
+import { PDFDocument } from "@cantoo/pdf-lib";
 
 /**
  * @param {string | Uint8Array | ArrayBuffer} pdfBytes
@@ -9,14 +9,6 @@ export default async function flattenPDF(pdfBytes) {
 
   const form = pdfDoc.getForm();
 
-  for (const field of form.getFields()) {
-    // See: https://github.com/Hopding/pdf-lib/issues/1168#issuecomment-1321581900
-    if (field.isExported()) {
-      while (field.acroField.getWidgets().length) {
-          field.acroField.removeWidget(0);
-      }
-    }
-  }
   form.flatten();
 
   return pdfDoc.save();

--- a/package.json
+++ b/package.json
@@ -24,6 +24,6 @@
   "homepage": "https://github.com/kanselarij-vlaanderen/pdf-flattener-service#readme",
   "dependencies": {
     "@lblod/mu-auth-sudo": "^0.6.1",
-    "pdf-lib": "^1.17.1"
+    "@cantoo/pdf-lib": "^2.4.1"
   }
 }


### PR DESCRIPTION
Hopding's version is unmaintained. Cantoo's seems to be more up-to-date.