### PR TITLE
KAS-5030 fix filter outside graph finds propagated flattened pieces

### DIFF
--- a/config/piece.js
+++ b/config/piece.js
@@ -40,8 +40,9 @@ WHERE {
       dbpedia:fileExtension ?extension ;
       dct:created ?created .
     ?physicalUri nie:dataSource ?file .
+
+    FILTER NOT EXISTS { ?piece sign:getekendStukKopie ?signedPieceCopy }
   }
-  FILTER NOT EXISTS { ?piece sign:getekendStukKopie ?signedPieceCopy }
 } LIMIT 1`;
 
   const response = await queryFunction(queryString);


### PR DESCRIPTION
having the FILTER NOT EXISTS outside means that even after deletions of flattened pieces on the main graph it does not allow you to reflatten until yggdrasil has cleaned all data on all graphs.